### PR TITLE
feat: 添加 Electron 版本检测和 macOS Sequoia 性能问题标识

### DIFF
--- a/ChromiumCertificate/ChromiumBasedAppListView.swift
+++ b/ChromiumCertificate/ChromiumBasedAppListView.swift
@@ -34,7 +34,16 @@ struct ChromiumBasedAppListView: View {
 					ForEach(Array(chromiumAppsList.enumerated()), id: \.element.id) { index, chromiumApp in
 						HStack {
 							VStack(alignment: .leading) {
-								Text(chromiumApp.name).bold()
+								HStack {
+									if let isTahoeFixed = chromiumApp.isTahoeFixed {
+										Text(isTahoeFixed ? "✅" : "❌")
+									}
+									Text(chromiumApp.name).bold()
+								}
+								if let version = chromiumApp.electronVersion {
+									Text("Electron \(version)")
+										.font(.system(.caption, design: .monospaced))
+								}
 								Text(chromiumApp.path)
 									.font(.system(.caption, design: .monospaced))
 							}
@@ -46,6 +55,15 @@ struct ChromiumBasedAppListView: View {
 						}
 					}
 				}.padding()
+
+				if chromiumAppsList.contains(where: { $0.isTahoeFixed != nil }) {
+					Divider()
+					VStack(alignment: .leading, spacing: 4) {
+						Text("关于 macOS Sequoia 性能问题：").font(.caption).bold()
+						Text("✅ = Electron 版本已修复（≥36.9.2, ≥37.6.0, ≥38.2.0, ≥39.0.0）").font(.caption2)
+						Text("❌ = Electron 版本存在性能问题").font(.caption2)
+					}.padding().frame(maxWidth: .infinity, alignment: .leading)
+				}
 			}
 		}.frame(width: 300).frame(minHeight: 0, maxHeight: 300)
 	}


### PR DESCRIPTION
- 在 ChromiumApp 模型中添加 electronVersion 和 isTahoeFixed 属性
- 实现从 Info.plist 提取 Electron 版本号的功能
- 添加版本比较逻辑以检测是否修复了 Tahoe 性能问题
- 在应用列表界面显示 ✅/❌ 状态指示器和版本信息
- 添加图例说明固定版本标准（≥36.9.2, ≥37.6.0, ≥38.2.0, ≥39.0.0）

🤖 Generated with [Claude Code](https://claude.ai/code)