### PR TITLE
Make Chromium detection async with caching

### DIFF
--- a/ChromiumCertificate/ChromiumBasedAppListView.swift
+++ b/ChromiumCertificate/ChromiumBasedAppListView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ChromiumBasedAppListView: View {
 	@Binding var isPresented: Bool
 	
-	let chromiumAppsList: [ChromiumApp] = ChromiumDetector.detectChromiumApps()
+	@State private var chromiumAppsList: [ChromiumApp]? = ChromiumDetector.cachedApps
 	
 	var body: some View {
 		VStack(spacing: 0) {
@@ -26,46 +26,59 @@ struct ChromiumBasedAppListView: View {
 			
 			Divider()
 			
-			ScrollView {
-				if chromiumAppsList.isEmpty {
-					Text("LISTVIEW_NO_CHRIMIUM_APPS_FOUND").multilineTextAlignment(.center).padding()
-				}
-				VStack(spacing: 8) {
-					ForEach(Array(chromiumAppsList.enumerated()), id: \.element.id) { index, chromiumApp in
-						HStack {
-							VStack(alignment: .leading) {
-								HStack {
-									if let isTahoeFixed = chromiumApp.isTahoeFixed {
-										Text(isTahoeFixed ? "LISTVIEW_FIXED_INDICATOR" : "LISTVIEW_UNFIX_INDICATOR")
+			if let chromiumAppsList = chromiumAppsList {
+				ScrollView {
+					if chromiumAppsList.isEmpty {
+						Text("LISTVIEW_NO_CHRIMIUM_APPS_FOUND").multilineTextAlignment(.center).padding()
+					}
+					VStack(spacing: 8) {
+						ForEach(Array(chromiumAppsList.enumerated()), id: \.element.id) { index, chromiumApp in
+							HStack {
+								VStack(alignment: .leading) {
+									HStack {
+										if let isTahoeFixed = chromiumApp.isTahoeFixed {
+											Text(isTahoeFixed ? "LISTVIEW_FIXED_INDICATOR" : "LISTVIEW_UNFIX_INDICATOR")
+										}
+										Text(chromiumApp.name).bold()
 									}
-									Text(chromiumApp.name).bold()
-								}
-								if let version = chromiumApp.electronVersion {
-									Text("LISTVIEW_ELECTRON_VERSION_TAG \(version)")
+									if let version = chromiumApp.electronVersion {
+										Text("LISTVIEW_ELECTRON_VERSION_TAG \(version)")
+											.font(.system(.caption, design: .monospaced))
+									}
+									Text(chromiumApp.path)
 										.font(.system(.caption, design: .monospaced))
 								}
-								Text(chromiumApp.path)
-									.font(.system(.caption, design: .monospaced))
+								Spacer()
 							}
-							Spacer()
+							
+							if index < chromiumAppsList.count - 1 {
+								Divider()
+							}
 						}
-						
-						if index < chromiumAppsList.count - 1 {
-							Divider()
-						}
-					}
-				}.padding()
+					}.padding()
 
-				if chromiumAppsList.contains(where: { $0.isTahoeFixed != nil }) {
-					Divider()
-					VStack(alignment: .leading, spacing: 4) {
-						Text("LISTVIEW_PERFORMANCE_ISSUE_TITLE").font(.caption).bold()
-						Text("LISTVIEW_PERFORMANCE_ISSUE_PARAGRAPH_1").font(.caption2)
-						Text("LISTVIEW_PERFORMANCE_ISSUE_PARAGRAPH_2").font(.caption2)
-					}.padding().frame(maxWidth: .infinity, alignment: .leading)
+					if chromiumAppsList.contains(where: { $0.isTahoeFixed != nil }) {
+						Divider()
+						VStack(alignment: .leading, spacing: 4) {
+							Text("LISTVIEW_PERFORMANCE_ISSUE_TITLE").font(.caption).bold()
+							Text("LISTVIEW_PERFORMANCE_ISSUE_PARAGRAPH_1").font(.caption2)
+							Text("LISTVIEW_PERFORMANCE_ISSUE_PARAGRAPH_2").font(.caption2)
+						}.padding().frame(maxWidth: .infinity, alignment: .leading)
+					}
+				}
+			} else {
+				VStack {
+					Spacer()
+					ProgressView()
+					Spacer()
 				}
 			}
 		}.frame(width: 300).frame(minHeight: 0, maxHeight: 300)
+		.onAppear {
+			ChromiumDetector.detectChromiumApps { apps in
+				self.chromiumAppsList = apps
+			}
+		}
 	}
 }
 

--- a/ChromiumCertificate/ChromiumDetector.swift
+++ b/ChromiumCertificate/ChromiumDetector.swift
@@ -25,30 +25,44 @@ enum ChromiumType: String, CaseIterable {
 
 class ChromiumDetector {
     
-    static func detectChromiumApps() -> [ChromiumApp] {
-        var chromiumApps: [ChromiumApp] = []
-        let fileManager = FileManager.default
-        let applicationsURL = URL(fileURLWithPath: "/Applications")
+    static var cachedApps: [ChromiumApp]?
+
+    static func detectChromiumApps(forceReload: Bool = false, completion: @escaping ([ChromiumApp]) -> Void) {
+        if !forceReload, let cached = cachedApps {
+            DispatchQueue.main.async { completion(cached) }
+            return
+        }
+
         
-        do {
-            let appURLs = try fileManager.contentsOfDirectory(
-                at: applicationsURL,
-                includingPropertiesForKeys: [.isDirectoryKey],
-                options: [.skipsHiddenFiles]
-            )
+        DispatchQueue.global(qos: .userInitiated).async {
+            var chromiumApps: [ChromiumApp] = []
+            let fileManager = FileManager.default
+            let applicationsURL = URL(fileURLWithPath: "/Applications")
             
-            for appURL in appURLs {
-                if appURL.pathExtension == "app" {
-                    if let chromiumApp = analyzeApp(at: appURL) {
-                        chromiumApps.append(chromiumApp)
+            do {
+                let appURLs = try fileManager.contentsOfDirectory(
+                    at: applicationsURL,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles]
+                )
+                
+                for appURL in appURLs {
+                    if appURL.pathExtension == "app" {
+                        if let chromiumApp = analyzeApp(at: appURL) {
+                            chromiumApps.append(chromiumApp)
+                        }
                     }
                 }
+            } catch {
+                print("Error reading applications directory: \(error)")
             }
-        } catch {
-            print("Error reading applications directory: \(error)")
+            
+            let sortedApps = chromiumApps.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            DispatchQueue.main.async {
+                self.cachedApps = sortedApps
+                completion(sortedApps)
+            }
         }
-        
-        return chromiumApps.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }
     
     private static func analyzeApp(at appURL: URL) -> ChromiumApp? {
@@ -117,57 +131,28 @@ class ChromiumDetector {
     }
     
     private static func hasElectronIdentifier(infoPlistPath: String) -> Bool {
-        guard FileManager.default.fileExists(atPath: infoPlistPath) else { return false }
-
-        let task = Process()
-        task.launchPath = "/usr/libexec/PlistBuddy"
-        task.arguments = ["-c", "Print CFBundleIdentifier", infoPlistPath]
-        
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError = Pipe()
-        
-        do {
-            try task.run()
-            task.waitUntilExit()
-            
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let output = String(data: data, encoding: .utf8) ?? ""
-            
-            return output.localizedCaseInsensitiveContains("electron")
-        } catch {
+        guard FileManager.default.fileExists(atPath: infoPlistPath),
+              let data = try? Data(contentsOf: URL(fileURLWithPath: infoPlistPath)),
+              let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any],
+              let bundleId = plist["CFBundleIdentifier"] as? String else {
             return false
         }
+        return bundleId.localizedCaseInsensitiveContains("electron")
     }
 
     private static func getElectronVersionInfo(at frameworkURL: URL) -> (version: String?, isFixed: Bool?) {
-        let infoPlistPath = frameworkURL.appendingPathComponent("Resources/Info.plist").path
-        guard FileManager.default.fileExists(atPath: infoPlistPath) else { return (nil, nil) }
-
-        let task = Process()
-        task.launchPath = "/usr/bin/plutil"
-        task.arguments = ["-extract", "CFBundleVersion", "raw", infoPlistPath]
-
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError = Pipe()
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            guard task.terminationStatus == 0 else { return (nil, nil) }
-
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let versionString = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-            if versionString.isEmpty { return (nil, nil) }
-
-            let isFixed = isElectronVersionFixed(versionString)
-            return (versionString, isFixed)
-        } catch {
+        let infoPlistURL = frameworkURL.appendingPathComponent("Resources/Info.plist")
+        guard FileManager.default.fileExists(atPath: infoPlistURL.path),
+              let data = try? Data(contentsOf: infoPlistURL),
+              let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any],
+              let versionString = plist["CFBundleVersion"] as? String else {
             return (nil, nil)
         }
+        
+        let trimmed = versionString.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return (nil, nil) }
+        
+        return (trimmed, isElectronVersionFixed(trimmed))
     }
 
     private static func isElectronVersionFixed(_ versionString: String) -> Bool {
@@ -190,22 +175,4 @@ class ChromiumDetector {
         return false
     }
     
-    static func getChromiumAppCount() -> Int {
-        return detectChromiumApps().count
-    }
-    
-    static func getChromiumAppNames() -> [String] {
-        return detectChromiumApps().map { $0.name }
-    }
-    
-    static func getChromiumAppsByType() -> [ChromiumType: [ChromiumApp]] {
-        let apps = detectChromiumApps()
-        var groupedApps: [ChromiumType: [ChromiumApp]] = [:]
-        
-        for type in ChromiumType.allCases {
-            groupedApps[type] = apps.filter { $0.type == type }
-        }
-        
-        return groupedApps
-    }
 }

--- a/ChromiumCertificate/ContentView.swift
+++ b/ChromiumCertificate/ContentView.swift
@@ -29,8 +29,7 @@ extension View {
 }
 
 struct ContentView: View {
-	let count = ChromiumDetector.getChromiumAppCount()
-	
+	@State private var count: Int? = nil
 	@State private var presentSheet: Bool = false
 	@Environment(\.locale) private var locale
 	
@@ -38,18 +37,25 @@ struct ContentView: View {
 		ZStack {
 			Image("AnnouncementBg").resizable().frame(width: 640, height: 480).offset(x: 0, y: -12)
 			VStack {
-				Text("MAINVIEW_CHROMIUM_COUNTER \(count)")
-					.multilineTextAlignment(.center)
-					.font(.system(size: 35, weight: .semibold))
-					.foregroundColor(Color("TextColor"))
-					.stroke(color: Color("TextBorderColor"), width: 5)
-					.padding(.horizontal)
+				if let count = count {
+					Text("MAINVIEW_CHROMIUM_COUNTER \(count)")
+						.multilineTextAlignment(.center)
+						.font(.system(size: 35, weight: .semibold))
+						.foregroundColor(Color("TextColor"))
+						.stroke(color: Color("TextBorderColor"), width: 5)
+						.padding(.horizontal)
+				} else {
+					ProgressView()
+						.scaleEffect(1.5)
+						.padding()
+				}
 				
 				Button {
 					self.presentSheet.toggle()
 				} label: {
 					Text("MAINVIEW_SEE_LIST").font(.system(size: 20)).padding(.horizontal).padding(.vertical, 8)
 				}
+				.disabled(count == nil)
 				.buttonStyle(.borderedProminent)
 				.tint(.red)
 				.sheet(isPresented: self.$presentSheet) {
@@ -58,6 +64,11 @@ struct ContentView: View {
 			}
 		}
 		.frame(width: 640, height: 440)
+		.onAppear {
+			ChromiumDetector.detectChromiumApps { apps in
+				self.count = apps.count
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
- **Performance Improvement**: Converted Chromium detection to an asynchronous, cached API and updated the UI to use stateful loading, preventing blocking the main thread.
- **Plist Handling Optimization**: Replaced external Process calls with PropertyListSerialization and getElectronVersionInfo/hasElectronIdentifier for plist reading, reducing reliance on external processes.
- **UI Enhancements**: Implemented @State, ProgressView, and asynchronous rendering to improve user experience during loading.
